### PR TITLE
feat: custom admonitions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,9 +1,9 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require("prism-react-renderer/themes/github")
-const darkCodeTheme = require("prism-react-renderer/themes/dracula")
-
+const lightCodeTheme = require("prism-react-renderer/themes/github");
+const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const admonitions = require("remark-admonitions");
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Aries JavaScript Documentation",
@@ -31,17 +31,42 @@ const config = {
     [
       "classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: "guides",
           routeBasePath: "guide",
-
           sidebarPath: require.resolve("./sidebars.js"),
+          remarkPlugins: [
+            [
+              admonitions,
+              {
+                infima: true,
+                icons: "emoji",
+                customTypes: {
+                  holder: {
+                    keyword: "issuer",
+                    emoji: "🗄",
+                    ifmClass: "alert alert--holder",
+                  },
+                  issuer: {
+                    keyword: "issuer",
+                    emoji: "📄",
+                    ifmClass: "alert alert--issuer",
+                  },
+                  verifier: {
+                    keyword: "verifier",
+                    emoji: "👮",
+                    ifmClass: "alert alert--verifier",
+                  },
+                },
+              },
+            ],
+          ],
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
-      }),
+      },
     ],
   ],
 
@@ -126,6 +151,6 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     }),
-}
+};
 
-module.exports = config
+module.exports = config;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,15 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+.admonition-holder {
+  --ifm-alert-background-color: #a29bff;
+}
+
+.admonition-issuer {
+  --ifm-alert-background-color: #00ba2b;
+}
+
+.admonition-verifier {
+  --ifm-alert-background-color: #fd029d;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,23 +1,24 @@
-import React from 'react';
-import clsx from 'clsx';
-import Layout from '@theme/Layout';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import styles from './index.module.css';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import React from "react";
+import clsx from "clsx";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import styles from "./index.module.css";
+import HomepageFeatures from "@site/src/components/HomepageFeatures";
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+    <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            to="/guide/getting-started/installation/"
+          >
+            Get Started 🚀
           </Link>
         </div>
       </div>
@@ -26,11 +27,12 @@ function HomepageHeader() {
 }
 
 export default function Home(): JSX.Element {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description="Description will go into a meta tag in <head />"
+    >
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
I have added some custom admonitions with their own styling and keywords to distinguish between the different roles (holder, verifier, issuer) in our tutorials. The styling/colouring sucks and definitely needs improvement, but it's a start.

For example, in order to add an admonition for a holder, use the following syntax:

```
:::holder
Content goes here
:::
```

Needless to say, this syntax is the same for the issuer and verifier.

As far as I know, these admonitions can contain anything that is considered valid (remark) markdown. So you should be able to include lists, tables, snippets, etc.

It currently looks like this:

<img width="774" alt="CleanShot 2022-05-19 at 01 05 33@2x" src="https://user-images.githubusercontent.com/18397186/169169465-52972798-9f06-42f2-8319-733a75e0e524.png">

✌️

Signed-off-by: Karim Stekelenburg <karim@animo.id>
