### PR TITLE
feat: add snippet import with section comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.3.1",
+    "raw-loader": "^4.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-docusaurus-tabs": "^0.2.0"

--- a/src/theme/CodeBlock/Line/index.js
+++ b/src/theme/CodeBlock/Line/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import Line from "@theme-original/CodeBlock/Line";
+
+export default function LineWrapper(props) {
+  // console.log('From LineWrapper, props:', props)
+
+  return (
+    <>
+      <Line {...props} />
+    </>
+  );
+}

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,0 +1,90 @@
+import React, { isValidElement } from "react";
+import useIsBrowser from "@docusaurus/useIsBrowser";
+import ElementContent from "@theme/CodeBlock/Content/Element";
+import StringContent from "@theme/CodeBlock/Content/String";
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+
+function maybeStringifyChildren(children) {
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return children;
+  } // The children is now guaranteed to be one/more plain strings
+
+  return Array.isArray(children) ? children.join("") : children;
+}
+
+const parseSectionNumber = (metaString) => {
+  return metaString
+    .split(" ")
+    .find((x) => x.match(/^section-/))
+    ?.substr(8);
+};
+
+const getSectionContent = (sectionNumber, contentBody) => {
+  const startToken = `start-section-${sectionNumber}`;
+  const endToken = `end-section-${sectionNumber}`;
+
+  const contentArray = contentBody.split("\n");
+
+  const startIndex = contentArray.indexOf(
+    contentArray.find((x) => x.includes(startToken))
+  );
+  const endIndex = contentArray.indexOf(
+    contentArray.find((x) => x.includes(endToken))
+  );
+
+  const sectionContent = contentArray.slice(startIndex + 1, endIndex);
+
+  return sectionContent.join("\r\n");
+};
+
+const parseFileName = (metaString) => {
+  return metaString.split(" ").find((x) => x.match(/.(js|ts)$/));
+};
+
+const removeSectionMarkers = (sectionContent) => {
+  console.log(sectionContent);
+
+  const sectionContentArr = sectionContent.split("\n");
+  const withoutMarkers = sectionContentArr.filter((x) => !x.match(/section-/));
+  console.log(withoutMarkers.join("\r\n"));
+  return withoutMarkers.join("\r\n");
+};
+
+export default function CodeBlock({ children: rawChildren, ...props }) {
+  // The Prism theme on SSR is always the default theme but the site theme can
+  // be in a different mode. React hydration doesn't update DOM styles that come
+  // from SSR. Hence force a re-render after mounting to apply the current
+  // relevant styles.
+  const isBrowser = useIsBrowser();
+  const children = maybeStringifyChildren(rawChildren);
+
+  let snippetContent;
+
+  try {
+    snippetContent = require(`!!raw-loader!../../../snippets/${parseFileName(
+      props.metastring
+    )}`).default;
+  } catch {}
+  const CodeBlockComp =
+    typeof children === "string" ? StringContent : ElementContent;
+
+  const sectionNumber = parseSectionNumber(props.metastring);
+
+  let sectionContent;
+
+  if (snippetContent) {
+    sectionContent = sectionNumber
+      ? getSectionContent(sectionNumber, snippetContent)
+      : removeSectionMarkers(snippetContent);
+  }
+  return (
+    <CodeBlockComp key={String(isBrowser)} {...props}>
+      {sectionContent ? sectionContent : children}
+    </CodeBlockComp>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6161,6 +6161,14 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"


### PR DESCRIPTION
### Description
This PR adds the ability to import snippets from a source file, instead of writing it directly in the markdown files themselves. This enables us to run/test the snippets before publishing a new version of the docs.

A runnable/testable piece of code however, often includes a lot of stuff you might not want to display as part of a snippet. That is why this PR also includes a custom mechanism to partially display sections of the source file.

It works like this:

#### Create a source file
First, create a source file in the `/snippets` directory. For the sake of this example we'll call the file `/snippets/myCoolCode.ts`

```ts
// start-section-1
const sectionOneStuff = () => {
  doSomeStuffBro();
  // doSomeStuff
};
// end-section-1
const notInAnySectionStuff = "bar";
// start-section-2
const sectionTwoStuff = "fooBar";
// end-section-2
```

As you can see the code is annotated with `//start-section-n` and `//end-section-n` comments. These comments define the sections we can later display separately.

#### Add the snippet to a markdown file
Inside the documentation, you can import the source file as follows:

````
```typescript myCoolCode.ts
```
````

This will import the source file, strip all the section related comments, and display the entire file as follows:

```ts
const sectionOneStuff = () => {
  doSomeStuffBro();
  // doSomeStuff
};

const notInAnySectionStuff = "bar";

const sectionTwoStuff = "fooBar";
```

#### Displaying a specific section
In order to display a specific section, simply add `section-n` after the import, like this:

````
```typescript myCoolCode.ts section-1
```
````

This will give you the output:

```ts
const sectionOneStuff = () => {
  doSomeStuffBro();
  // doSomeStuff
};
```

#### Fallback
This feature also includes a fallback mechanism in case the imported file can't be found. You can define what to display if the file can be found by simply adding a body to the markdown code block like this:

````
```typescript thisFileDoesNotExist.ts section-1
// Oops, the imported file doesn't seem to exist
```
````

This will simply render the code block instead of throwing an error at runtime:

```typescript
// Oops, the imported file doesn't seem to exist
```

### Final remarks
As can be seen in the example snippet, not all lines of code are part of a section. This enables you to define sections that only include what is really relevant to the user. **However**, be aware that when a source file is imported without specifying a section (using the `section-n` syntax), these lines will be included in the rendering.

Signed-off-by: Karim Stekelenburg <karim@animo.id>
