### PR TITLE
docs: add afj updating guide

### DIFF
--- a/guides/updating/index.md
+++ b/guides/updating/index.md
@@ -1,0 +1,38 @@
+# Updating
+
+This section will cover everything you need to know about updating Aries Framework JavaScript to a newer version.
+
+## Versioning
+
+Aries Framework JavaScript follows [semantic versioning](https://semver.org/). This means that major version changes (**1**.0.0) are considered breaking changes. When features are added this is a minor version change (0.**1**.0). For bug fixes the patch version change is used (0.0.**1**).
+
+While AFJ is still in pre-1.0.0 version, the version change types are shifted to the right. This means a major version change is now a minor change (0.**1**.0) and a minor change is now a patch change (0.0.**1**). This is done to keep the version below 1.0.0, indicating the framework is still in early development and users can expect more breaking changes that when the version has already reached 1.0.0.
+
+This means if the second number in the version (0.**1**.0) changes, you need to be careful with updating and always consult this page for update instructions. If only the third number changes (0.0.**1**), you can update without any issues.
+
+## Types of breaking changes
+
+Updates to AFJ bring new features and improvements to the framework. To better adapt the framework to new features we sometimes make breaking changes that will improve how AFJ works. There's two parts to updates with breaking changes:
+
+1. Breaking code changes
+2. Breaking storage changes
+
+### Breaking Code Changes
+
+Breaking changes to code means changes to how you interact with AFJ. This includes methods being renamed, moved to another module or extended to better integrate with new features. We'll try to cover all breaking changes in migration guides, so you know exactly what is needed to update to a new version and keep the same functionality.
+
+:::info
+
+If you encounter any breaking changes that aren't mentioned in the migration docs, please open an issue in the [Aries JavaScript Docs](https://github.com/animo/aries-javascript-docs/issues) repository, or directly create a PR describing the change.
+
+:::
+
+### Breaking Storage Changes
+
+Breaking changes to storage are a bit more complex to deal with. While breaking changes to code only require you to update your code once, breaking changes to storage needs to be updated for every agent instance. Luckily, we've made the migration as easy as possible for you using the [Update Assistant](./update-assistant.md). The Update Assistant will update all storage objects to the storage model that is expected by the newest version. If a version made changes to the storage, this will be explicitly mentioned in the migration guide. See the [Update Assistant](/guides/updating/update-assistant.md) documentation for detailed instructions on how to use the update assistant.
+
+## Migration Guides
+
+Currently the following migration guides are available:
+
+- [Migrating from AFJ 0.1.0 to 0.2.x](./versions/0.1-to-0.2.md)

--- a/guides/updating/index.md
+++ b/guides/updating/index.md
@@ -1,4 +1,4 @@
-# Updating
+# Updating AFJ
 
 This section will cover everything you need to know about updating Aries Framework JavaScript to a newer version.
 

--- a/guides/updating/update-assistant.md
+++ b/guides/updating/update-assistant.md
@@ -1,0 +1,129 @@
+# Update Assistant
+
+The Update Assistant helps you update the storage objects from AFJ to newer versions. This documents describes the different ways you can leverage the Update Assistant from fully managed to more manual approaches.
+
+- [Update Strategies](#update-strategies)
+  - [Manually instantiating the update assistant on agent startup](#manually-instantiating-the-update-assistant-on-agent-startup)
+  - [Storing the agent storage version outside of the agent storage](#storing-the-agent-storage-version-outside-of-the-agent-storage)
+  - [Automatically update on agent startup](#automatically-update-on-agent-startup)
+- [Backups](#backups)
+
+## Update Strategies
+
+There are three options on how to leverage the update assistant on agent startup:
+
+1. Manually instantiating the update assistant on agent startup
+2. Storing the agent storage version outside of the agent storage
+3. Automatically update on agent startup
+
+### Manually instantiating the update assistant on agent startup
+
+When the version of the storage is stored inside the agent storage, it means we need to check if the agent needs to be updated on every agent startup. We'll initialize the update assistant and check whether the storage is up to date. The advantage of this approach is that you don't have to store anything yourself, and have full control over the workflow.
+
+```ts
+import { UpdateAssistant, Agent } from "@aries-framework/core";
+
+// or @aries-framework/node
+import { agentDependencies } from "@aries-framework/react-native";
+
+// First create the agent
+const agent = new Agent(config, agentDependencies);
+
+// Then initialize the update assistant with the update config
+const updateAssistant = new UpdateAssistant(agent, {
+  v0_1ToV0_2: {
+    mediationRoleUpdateStrategy: "allMediator",
+  },
+});
+
+// Initialize the update assistant so we can read the current storage version
+// from the wallet. If you manually initialize the wallet you should do this _before_
+// calling initialize on the update assistant
+// await agent.wallet.initialize(walletConfig)
+await updateAssistant.initialize();
+
+// Check if the agent is up to date, if not call update
+if (!(await updateAssistant.isUpToDate())) {
+  await updateAssistant.update();
+}
+
+// Once finished initialize the agent. You should do this on every launch of the agent
+await agent.initialize();
+```
+
+### Storing the agent storage version outside of the agent storage
+
+When the version of the storage is stored outside of the agent storage, you don't have to initialize the `UpdateAssistant` on every agent agent startup. You can just check if the storage version is up to date and instantiate the `UpdateAssistant` if not. The advantage of this approach is that you don't have to instantiate the `UpdateAssistant` on every agent startup, but this does mean that you have to store the storage version yourself.
+
+When a wallet has been exported and later imported you don't always have the latest version available. If this is the case you can always rely on Method 1 or 2 for updating the wallet, and storing the version yourself afterwards. You can also get the current version by calling `await updateAssistant.getCurrentAgentStorageVersion()`. Do note the `UpdateAssistant` needs to be initialized before calling this method.
+
+```ts
+import { UpdateAssistant, Agent } from "@aries-framework/core";
+
+// or @aries-framework/node
+import { agentDependencies } from "@aries-framework/react-native";
+
+// The storage version will normally be stored in e.g. persistent storage on a mobile device
+let currentStorageVersion: VersionString = "0.1";
+
+// First create the agent
+const agent = new Agent(config, agentDependencies);
+
+// We only initialize the update assistant if our stored version is not equal
+// to the frameworkStorageVersion of the UpdateAssistant. The advantage of this
+// is that we don't have to initialize the UpdateAssistant to retrieve the current
+// storage version.
+if (currentStorageVersion !== UpdateAssistant.frameworkStorageVersion) {
+  const updateAssistant = new UpdateAssistant(agent, {
+    v0_1ToV0_2: {
+      mediationRoleUpdateStrategy: "recipientIfEndpoint",
+    },
+  });
+
+  // Same as with the previous strategy, if you normally call agent.wallet.initialize() manually
+  // you need to call this before calling updateAssistant.initialize()
+  await updateAssistant.initialize();
+
+  await updateAssistant.update();
+
+  // Store the version so we can leverage it during the next agent startup and don't have
+  // to initialize the update assistant again until a new version is released
+  currentStorageVersion = UpdateAssistant.frameworkStorageVersion;
+}
+
+// Once finished initialize the agent. You should do this on every launch of the agent
+await agent.initialize();
+```
+
+### Automatically update on agent startup
+
+This is by far the easiest way to update the agent, but has the least amount of flexibility and is not configurable. This means you will have to use the default update options to update the agent storage. You can find the default update config in the respective version migration guides (e.g. in [0.1-to-0.2](/guides/updating/versions/0.1-to-0.2.md)).
+
+```ts
+import { UpdateAssistant, Agent } from "@aries-framework/core";
+
+// or @aries-framework/node
+import { agentDependencies } from "@aries-framework/react-native";
+
+// First create the agent, setting the autoUpdateStorageOnStartup option to true
+const agent = new Agent(
+  { ...config, autoUpdateStorageOnStartup: true },
+  agentDependencies
+);
+
+// Then we call initialize, which under the hood will call the update assistant if the storage is not update to date.
+await agent.initialize();
+```
+
+## Backups
+
+Before starting the update, the update assistant will automatically create a backup of the wallet. If the migration succeeds the backup won't be used. If the backup fails, another backup will be made of the migrated wallet, after which the backup will be restored.
+
+The backups can be found at the following locations. The `backupIdentifier` is generated at the start of the update process and generated based on the current timestamp.
+
+- Backup path: `${agent.config.fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
+- Migration backup: `${agent.config.fileSystem.basePath}/afj/migration/backup/${backupIdentifier}-error`
+
+> In the future the backup assistant will make a number of improvements to the recovery process. Namely:
+>
+> - Do not throw an error if the update fails, but rather return an object that contains the status, and include the backup paths and backup identifiers.

--- a/guides/updating/versions/0.1-to-0.2.md
+++ b/guides/updating/versions/0.1-to-0.2.md
@@ -1,0 +1,379 @@
+# Migrating from AFJ 0.1.0 to 0.2.x
+
+## Breaking Code Changes
+
+<!-- - Credentials Module
+  - methods now take objects
+  - credentialFormats
+  - protocolVersions
+  - Attributes / schemas/ cred defs in credential record after accepting
+  - removed messages
+- Connections
+  - move to OOB module for create/receive invitation
+  - state is now always `DidExchangeState`
+  - dids are now fully qualified dids (old did still stored in did record)
+
+### Credentials Module
+
+The credentials module has been updated to support multiple credential formats and protocol versions. The 0.2.0 release doesn't add support for new
+
+```ts
+await agent.credentials.offerCredential({
+  credentialRecordId: 'credentialRecordId',
+  credentialFormats: {
+    indy: {
+      credentialDefinitionId: 'credentialDefinitionId',
+      attributes: 'attributes',
+    },
+  },
+})
+``` -->
+
+### Credentials Module
+
+> TODO
+
+### Connections Module
+
+Version 0.2.0 added support for the [Out of Band protocol](https://github.com/hyperledger/aries-rfcs/blob/main/features/0434-outofband/README.md) with support for the [DID Exchange protocol](https://github.com/hyperledger/aries-rfcs/tree/main/features/0023-did-exchange). Internally AFJ now uses out of band invitations for all connections, even if you're connecting using the old invitations from the [Connection protocol](https://github.com/hyperledger/aries-rfcs/tree/main/features/0160-connection-protocol).
+
+#### Creating a Legacy Invitation
+
+The `createInvitation` method on the connections module has been moved to the out of band module and renamed to `createLegacyInvitation`. The method is not planned to be removed in the near future, the legacy merely indicates this will create an RFC 0160 connection invitation. Internally AFJ creates an out of band invitation and transforms it into a legacy invitation. If you want to create an out of band invitation instead, you should use `oob.createInvitation`.
+
+<!--tabs-->
+
+##### 0.1.0
+
+```ts
+const { connectionRecord, invitation } = await agent.connections.createInvitation({
+  /* config */
+})
+
+const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
+```
+
+##### 0.2.x
+
+```ts
+const { outOfBandRecord, invitation } = await agent.oob.createLegacyInvitation({
+  /* config */
+})
+
+const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
+```
+
+Important thing to note here is that the `oob.createLegacyInvitation` does not return a connection record, but rather an out of band record. Because out of band also supports connection-less scenarios, a connection record is not created until a connection request is received (or sent in the case of the invitee role).
+
+You can listen for connection state change events that are associated with a specific out of band id. This allows you to link a connection to an invitation you created.
+
+```ts
+// Listen for connection state changed events associated with the out of band record
+agent.events.on<ConnectionStateChangedEvent>(ConnectionEventTypes.ConnectionStateChanged, (event) => {
+  if (event.payload.connectionRecord.outOfBandId === outOfBandRecord.id) {
+    console.log(`Connection state changed for connection with out of band id ${outOfBandRecord.id}`)
+  }
+})
+```
+
+It is also possible to retrieve all connection records associated with an out of band invitation. Because of multi use invitations, there could be multiple connection records associated with a single out of band invitation. Instead of having a separate connection record that will always stay in the invited state, the out of band record will now handle the multi use capabilities of an invitation.
+
+```ts
+// Retrieve all connections associated with an out of band id
+const connections = await agent.connections.findAllByOutOfBandId(outOfBandRecord.id)
+```
+
+<!--/tabs-->
+
+#### Receiving a Legacy Invitation
+
+The `receiveInvitation` and `receiveInvitationFromUrl` methods on the connections module have also been moved to the out of band module. Both methods support the new out of band invitations and the legacy RFC 0160 connection invitations. Internally AFJ converts the old invitations to out of band invitations.
+
+<!--tabs-->
+
+##### 0.1.0
+
+```ts
+const invitationUrl = 'https://example.com?c_i=eyXXX'
+
+// Receive invitation directly from url
+const connectionRecord = await agent.connections.receiveInvitationFromUrl(invitationUrl, {
+  /* config */
+})
+
+// Parse invitation and receive invitation
+const parsedInvitation = await ConnectionInvitationMessage.fromUrl(invitationUrl)
+const connectionRecord = await agent.connections.receiveInvitation(parsedInvitation, {
+  /* config */
+})
+```
+
+##### 0.2.x
+
+```ts
+const invitationUrl = 'https://example.com?c_i=eyXXX'
+
+// Receive invitation directly from url
+const { outOfBandRecord, connectionRecord } = await agent.oob.receiveInvitationFromUrl(invitationUrl, {
+  /* config */
+})
+
+// Parse invitation and receive invitation
+const parsedInvitation = await agent.oob.parseInvitation(invitationUrl)
+const secondConnectionRecord = await agent.oob.receiveInvitation(parsedInvitation, {
+  /* config */
+})
+```
+
+The new receive invitation methods on the out of band module won't always return a connection record anymore. The out of band invitation may not contain any handshake protocols. In the case of receiving a connection invitation you will always receive a connection record though, as you can't use it for connection-less invitations.
+
+<!--/tabs-->
+
+#### Updating to use `DidExchangeState`
+
+> TODO
+
+### Updating Custom Messages to the New Message Type Objects
+
+Although this isn't a breaking change to the public API of the framework, it is something that you will need to take into account when creating custom modules. Starting from AFJ 0.2.0 we now support handling messages with different minor versions (e.g. receive a message with `@type` version 1.1 while we only support 1.0). With this change messages must now declare the message type as an `ParsedMessageType` object. We've added an `parseMessageType` util method that can help with this.
+
+<!--tabs-->
+
+#### 0.1.0
+
+```ts
+import { AgentMessage } from '@aries-framework/core'
+import { Equals } from 'class-validator'
+
+class MyMessage extends AgentMessage {
+  @Equals(MyMessage.type)
+  public readonly type = MyMessage.type
+  public static readonly type = 'https://didcomm.org/my-protocol/1.0/my-type'
+}
+```
+
+#### 0.2.x
+
+```ts
+import { AgentMessage, IsValidMessageType, parseMessageType } from '@aries-framework/core'
+import { Equals } from 'class-validator'
+
+class MyMessage extends AgentMessage {
+  // use IsValidMessageType instead of Equals
+  @IsValidMessageType(MyMessage.type)
+  // append .messageTypeUri to get the actual URI when instantiating a message
+  public readonly type = MyMessage.type.messageTypeUri
+  // use parseMessageType to get the message type object from a type. You can declare the object yourself, but this is the recommended way
+  public static readonly type = parseMessageType('https://didcomm.org/my-protocol/1.0/my-type')
+}
+```
+
+<!--/tabs-->
+
+## Breaking Storage Changes
+
+The 0.2.0 release is heavy on breaking changes to the storage format. This is not what we intend to do with every release. But as there's not that many people yet using the framework in production, and there were a lot of changes needed to keep the API straightforward, we decided to bundle a lot of breaking changes in this one release.
+
+Below all breaking storage changes are explained in as much detail as possible. The update assistant provides all tools to migrate without a hassle, but it is important to know what has changed. All examples only show the keys that have changed, unrelated keys in records have been omitted.
+
+See the [Update Assistant](/guides/updating/update-assistant.md) documentation for a guide on how to use the update assistant.
+
+The following config can be provided to the update assistant to migrate from 0.1.0 to 0.2.0:
+
+```json
+{
+  "v0_1ToV0_2": {
+    "mediationRoleUpdateStrategy": "<mediationRoleUpdateStrategy>"
+  }
+}
+```
+
+### Credential Metadata
+
+The credential record had a custom `metadata` property in pre-0.1.0 storage that contained the `requestMetadata`, `schemaId` and `credentialDefinition` properties. Later a generic metadata API was added that only allows objects to be stored. Therefore the properties were moved into a different structure.
+
+<!--tabs-->
+
+#### 0.1.0
+
+```json
+{
+  "requestMetadata": <value of requestMetadata>,
+  "schemaId": "<value of schemaId>",
+  "credentialDefinitionId": "<value of credential definition id>"
+}
+```
+
+#### 0.2.x
+
+```json
+{
+  "_internal/indyRequest": <value of requestMetadata>,
+  "_internal/indyCredential": {
+    "schemaId": "<value of schemaId>",
+    "credentialDefinitionId": "<value of credential definition id>"
+  }
+}
+```
+
+Accessing the `credentialDefinitionId` and `schemaId` properties will now be done by retrieving the `CredentialMetadataKeys.IndyCredential` metadata key.
+
+```ts
+const indyCredential = credentialRecord.metadata.get(CredentialMetadataKeys.IndyCredential)
+
+// both properties are optional
+indyCredential?.credentialDefinitionId
+indyCredential?.schemaId
+```
+
+<!--/tabs-->
+
+### Migrate Credential Record Properties
+
+In 0.2.0 the v1 DIDComm messages have been moved out of the credential record into separate records using the DidCommMessageRepository. The migration scripts extracts all messages (proposalMessage, offerMessage, requestMessage, credentialMessage) and moves them into the DidCommMessageRepository.
+
+With the addition of support for different protocol versions the credential record now stores the protocol version. With the addition of issue credential v2 support, other credential formats than indy can be used, and multiple credentials can be issued at once. To account for this the `credentialId` has been replaced by the `credentials` array. This is an array of objects containing the `credentialRecordId` and the `credentialRecordType`. For all current credentials the `credentialRecordType` will always be `indy`.
+
+<!--tabs-->
+
+#### 0.1.0
+
+```json
+{
+  "credentialId": "09e46da9-a575-4909-b016-040e96c3c539",
+  "proposalMessage": { ... },
+  "offerMessage": { ... },
+  "requestMessage": { ... },
+  "credentialMessage": { ... },
+}
+```
+
+#### 0.2.x
+
+```json
+{
+  "protocolVersion": "v1",
+  "credentials": [
+    {
+      "credentialRecordId": "09e46da9-a575-4909-b016-040e96c3c539",
+      "credentialRecordType": "indy"
+    }
+  ]
+}
+```
+
+<!--/tabs-->
+
+### Mediation Record Role
+
+The role in the mediation record was always being set to `MediationRole.Mediator` for both mediators and recipients. This didn't cause any issues, but would return the wrong role for recipients.
+
+In 0.2 a check is added to make sure the role of a mediation record matches with actions (e.g. a recipient can't grant mediation), which means it will throw an error if the role is not set correctly.
+
+Because it's not always possible detect whether the role should actually be mediator or recipient, a number of configuration options are provided on how the role should be updated using the `v0_1ToV0_2.mediationRoleUpdateStrategy` option:
+
+- `allMediator`: The role is set to `MediationRole.Mediator` for both mediators and recipients
+- `allRecipient`: The role is set to `MediationRole.Recipient` for both mediators and recipients
+- `recipientIfEndpoint` (**default**): The role is set to `MediationRole.Recipient` if their is an `endpoint` configured on the record. The endpoint is not set when running as a mediator. There is one case where this could be problematic when the role should be recipient, if the mediation grant hasn't actually occurred (meaning the endpoint is not set). This is probably the best approach
+  otherwise it is set to `MediationRole.Mediator`
+- `doNotChange`: The role is not changed
+
+Most agents only act as either the role of mediator or recipient, in which case the `allMediator` or `allRecipient` configuration is the most appropriate. If your agent acts as both a recipient and mediator, the `recipientIfEndpoint` configuration is the most appropriate. The `doNotChange` options is not recommended and can lead to errors if the role is not set correctly.
+
+### Extracting Did Documents to Did Repository
+
+The connection record previously stored both did documents from a connection in the connection record itself. Version 0.2.0 added a generic did storage that can be used for numerous usages, one of which is the storage of did documents for connection records.
+
+The migration script extracts the did documents from the `didDoc` and `theirDidDoc` properties from the connection record, updates them to did documents compliant with the did core spec, and stores them in the did repository. By doing so it also updates the unqualified dids in the `did` and `theirDid` fields generated by the indy-sdk to fully qualified `did:peer` dids compliant with the [Peer DID Method Specification](https://identity.foundation/peer-did-method-spec/).
+
+To account for the fact that the mechanism to migrate legacy did document to peer did documents is not defined yet, the legacy did and did document are stored in the did record metadata. This will be deleted later if we can be certain the did doc conversion to a `did:peer` did document is correct.
+
+<!--tabs-->
+
+#### 0.1.0
+
+```json
+{
+  "did": "BBPoJqRKatdcfLEAFL7exC",
+  "theirDid": "UppcJ5APts7ot5WX25943F",
+  "verkey": "GAb4NUvpBcHVCvtP45vTVa5Bp74vFg3iXzdp1Gbd68Wf",
+  "didDoc": <legacyDidDoc>,
+  "theirDidDoc": <legacyTheirDidDoc>,
+}
+```
+
+#### 0.2.x
+
+```json
+{
+  "did": "did:peer:1zQmXUaPPhPCbUVZ3hGYmQmGxWTwyDfhqESXCpMFhKaF9Y2A",
+  "theirDid": "did:peer:1zQmZMygzYqNwU6Uhmewx5Xepf2VLp5S4HLSwwgf2aiKZuwa"
+}
+```
+
+<!--/tabs-->
+
+### Migrating to the Out of Band Record
+
+With the addition of the out of band protocol, invitations are now stored in the `OutOfBandRecord`. In addition a new field `invitationDid` is added to the connection record that is generated based on the invitation service or did. This allows to reuse existing connections.
+
+The migration script extracts the invitation and other relevant data into a separate `OutOfBandRecord`. By doing so it converts the old connection protocol invitation into the new Out of band invitation message. Based on the service or did of the invitation, the `invitationDid` is populated.
+
+Previously when creating a multi use invitation, a connection record would be created with the `multiUseInvitation` set to true. The connection record would always be in state `invited`. If a request for the multi use invitation came in, a new connection record would be created. With the addition of the out of band module, no connection records are created until a request is received. So for multi use invitation this means that the connection record with multiUseInvitation=true will be deleted, and instead all connections created using that out of band invitation will contain the `outOfBandId` of the multi use invitation.
+
+<!--tabs-->
+
+#### 0.1.0
+
+```json
+{
+  "invitation": {
+    "@type": "https://didcomm.org/connections/1.0/invitation",
+    "@id": "04a2c382-999e-4de9-a1d2-9dec0b2fa5e4",
+    "recipientKeys": ["E6D1m3eERqCueX4ZgMCY14B4NceAr6XP2HyVqt55gDhu"],
+    "serviceEndpoint": "https://example.com",
+    "label": "test"
+  },
+  "multiUseInvitation": "false"
+}
+```
+
+#### 0.2.x
+
+```json
+{
+  "invitationDid": "did:peer:2.Ez6MksYU4MHtfmNhNm1uGMvANr9j4CBv2FymjiJtRgA36bSVH.SeyJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSJ9",
+  "outOfBandId": "04a2c382-999e-4de9-a1d2-9dec0b2fa5e4"
+}
+```
+
+<!--/tabs-->
+
+### Unifying Connection States and Roles
+
+With the addition of the did exchange protocol there are now two states and roles related to the connection record; for the did exchange protocol and for the connection protocol. To keep it easy to work with the connection record, all state and role values are updated to those of the `DidExchangeRole` and `DidExchangeState` enums.
+
+The migration script transforms all connection record state and role values to their respective values of the `DidExchangeRole` and `DidExchangeState` enums. For convenience a getter
+property `rfc0160ConnectionState` is added to the connection record which returns the `ConnectionState` value.
+
+<!--tabs-->
+
+#### 0.1.0
+
+```json
+{
+  "state": "invited",
+  "role": "inviter"
+}
+```
+
+#### 0.2.0
+
+```json
+{
+  "state": "invitation-sent",
+  "role": "responder"
+}
+```
+
+<!--/tabs-->

--- a/guides/updating/versions/0.1-to-0.2.md
+++ b/guides/updating/versions/0.1-to-0.2.md
@@ -1,37 +1,177 @@
 # Migrating from AFJ 0.1.0 to 0.2.x
 
+This document describes everything you need to know for updating AFJ 0.1.0 to 0.2.x. If you're not aware of how updating in AFJ works make sure to first read the guide on [Updating AFJ](/guides/updating/index.md).
+
 ## Breaking Code Changes
 
-<!-- - Credentials Module
-  - methods now take objects
-  - credentialFormats
-  - protocolVersions
-  - Attributes / schemas/ cred defs in credential record after accepting
-  - removed messages
-- Connections
-  - move to OOB module for create/receive invitation
-  - state is now always `DidExchangeState`
-  - dids are now fully qualified dids (old did still stored in did record)
+This section will list all breaking changes made to the public API of AFJ between version 0.1.0 and 0.2.0.
+
+:::info
+
+If you have custom modules take into account there could be a lot more breaking changes that aren't documented here. We try to make sure that the biggest breaking changes to the internal API are also documented here (e.g. see [Updating Custom Messages to the New Message Type Objects](#updating-custom-messages-to-the-new-message-type-objects)), but it is possible some breaking changes are not documented here (feel free to open PRs).
+
+:::
 
 ### Credentials Module
 
-The credentials module has been updated to support multiple credential formats and protocol versions. The 0.2.0 release doesn't add support for new
+#### Module API Updates
+
+With the addition of the issue credential v2 protocol and the preparation for multiple attachment formats (to be added in a later release), we've made some big changes to the credentials module API. Most changes are related to structure, so updating your code to the new API should be straightforward.
+
+Basically for all methods in the credential module you should take the following steps to update your code:
+
+1. Move all function parameters into a single object. All module methods now take a single object that contain all properties.
+2. For methods that initiate a protocol (starting from offer, proposal), you should pass `protocolVersion: 'v1'` to indicate we should use the v1 protocol. (v2 is also supported, but this focuses on the breaking changes, not the new features).
+3. All indy specific attributes (e.g. credentialDefinitionId) should be passed in the `credentialFormats.indy` object.
+4. The preview should now be passed as only the preview attributes (the the full preview) and provided in the `credentialFormats.indy` object.
+
+<!--tabs-->
+
+##### 0.1.0
+
+```ts
+await agent.credentials.offerCredential('connectionId', {
+  autoAcceptCredential: AutoAcceptCredential.Always,
+  comment: 'hello',
+
+  credentialDefinitionId: 'credentialDefinitionId',
+  preview: new CredentialPreview({
+    attributes: [new CredentialPreviewAttribute({ name: 'key', value: 'value' })],
+  }),
+})
+```
+
+##### 0.2.x
 
 ```ts
 await agent.credentials.offerCredential({
-  credentialRecordId: 'credentialRecordId',
+  connectionId: 'connectionId',
+  protocolVersion: 'v1',
+
+  autoAcceptCredential: AutoAcceptCredential.Always,
+  comment: 'hello',
+
   credentialFormats: {
     indy: {
       credentialDefinitionId: 'credentialDefinitionId',
-      attributes: 'attributes',
+      attributes: [{ name: 'key', value: 'value' }],
     },
   },
 })
-``` -->
+```
 
-### Credentials Module
+<!--/tabs-->
 
-> TODO
+#### Data from Received Messages only Stored in Record after Accepting
+
+Previously when we received a message from another connection we would store the relevant data from the exchange in the credential record. The values we would store were the `credentialDefinitionId` and `schemaId` in the credential metadata, and the `credentialAttributes` field.
+
+Starting with AFJ 0.2.0 the values are not stored in the credential record until after the message content has been accepted (in the case of an offer this mean after sending the request). This is to avoid ambiguity of the values in the credential record. If I have sent a proposal and then receive a proposal, should the credential record contain the values from the proposal or the values from the offer? The first one reflects our view on what the data should be, the second one reflects the latest data.
+
+We decided to make the record properties always hold our view of what the data should be, and only update it after accepting the contents of a received message (either using auto accept, or by calling the `acceptXXX` methods on the credential module).
+
+This is an important change and requires some updates to how you extract the relevant data from the offer (or other messages such the proposal). We've added a new `getFormatData` method on the credentials module that allows you to retrieve the attributes and format data for all messages in an exchange. One of the advantages of this approach is that we don't have to store all relevant data in the credential record anymore, which helps when adding new formats that don't match with the attributes used for indy credentials. In addition, the return value for this method is the same whether v1 or v2 of the protocol is used. This means your code should only care about the credential format (indy in this case) and doesn't have to worry about the protocol version.
+
+<!--tabs-->
+
+##### 0.1.0
+
+```ts
+agent.events.on<CredentialStateChangedEvent>(
+  CredentialEventTypes.CredentialStateChanged,
+  ({ payload: { credentialRecord } }) => {
+    const indyCredentialMetadata = credentialRecord.metadata.get(CredentialMetadataKeys.IndyCredential)
+
+    // Get credential definition id, schema id and attributes from offer
+    const credentialDefinitionId = indyCredentialMetadata?.credentialDefinitionId
+    const schemaId = indyCredentialMetadata?.schemaId
+    const attributes = credentialRecord.credentialAttributes
+  }
+)
+```
+
+##### 0.2.x
+
+```ts
+agent.events.on<CredentialStateChangedEvent>(
+  CredentialEventTypes.CredentialStateChanged,
+  async ({ payload: { credentialRecord } }) => {
+    const formatData = await agent.credentials.getFormatData(credentialRecord.id)
+
+    // Get credential definition id, schema id and attributes from offer
+    const credentialDefinitionId = formatData.offer?.cred_def_id
+    const schemaId = formatData.offer?.schema_id
+    const attributes = formatData.offerAttributes
+  }
+)
+```
+
+The return value of the `getFormatData` method is fully typed an directly returns the format data as encoded in the attachment. It also returns the `proposalAttributes` and `offerAttributes` values which contain the attributes for the indy credential. This is not part of the attachment data itself, but can be seen as the format data for the credential.
+
+```ts
+{
+  proposalAttributes: [{ name: 'key', value: 'value' mimeType: 'text/plain' }],
+  proposal: {
+    indy: { } // indy proposal as described in RFC 0592
+  },
+  offerAttributes: [{ name: 'key', value: 'value' mimeType: 'text/plain' }],
+  offer: {
+    indy: { } // indy offer as described in RFC 0592
+  },
+  request: {
+    indy: { } // indy request as described in RFC 0592
+  }
+  credential: {
+    indy: { } // indy credential as described in RFC 0592
+  }
+}
+```
+
+<!--/tabs-->
+
+#### Messages Extracted from Credential Record
+
+The DIDComm messages that were previously stored on the credential record, have been extracted to separate DIDComm message records. This makes it easier to work with multiple versions of the protocol internally, and keeps the credential exchange record agnostic of the protocol version. Instead of accessing the messages through the `proposalMessage`, `offerMessage`, `requestMessage` and `credentialMessage` parameters, we now expose dedicated methods on the credentials module to retrieve the message.
+
+With the addition of the v2 messages, all v1 messages have been prefixed with `V1` while v2 messages have been prefixed with `V2` (`V1ProposeCredentialMessage` and `V2ProposeCredentialMessage`). If you were using these messages classes throughout your codebase, update them to use the `V1` prefix.
+
+<!--tabs-->
+
+##### 0.1.0
+
+```ts
+const credentialRecord = await agent.credentials.getById('credentialRecordId')
+
+const proposalMessage = credentialRecord.proposalMessage
+const offerMessage = credentialRecord.offerMessage
+const requestMessage = credentialRecord.requestMessage
+const credentialMessage = credentialRecord.credentialMessage
+```
+
+##### 0.2.x
+
+```ts
+const credentialRecord = await agent.credentials.getById('credentialRecordId')
+
+const proposalMessage = await agent.credentials.findProposalMessage('credentialRecordId')
+const offerMessage = await agent.credentials.findOfferMessage('credentialRecordId')
+const requestMessage = await agent.credentials.findRequestMessage('credentialRecordId')
+const credentialMessage = await agent.credentials.findCredentialMessage('credentialRecordId')
+```
+
+Because AFJ now also supports the issue credential v2 protocol, the return type of this protocol has been changed to `V1XXXMessage | V2XXXMessage | null`. Take this into account when working with the messages.
+
+You can check if a message is a specific version by using the `instanceof` operator:
+
+```ts
+if (proposalMessage instanceof V1ProposeCredentialMessage) {
+  // do something
+}
+```
+
+Shared properties (e.g. the proposal messages for v1 and v2 both have the `credentialPreview` property) can be accessed without doing an instance check.
+
+<!--/tabs-->
 
 ### Connections Module
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,7 +33,10 @@ const sidebars = {
             {
               type: "category",
               label: "NodeJS",
-              link: { type: "doc", id: "getting-started/prerequisites/nodejs/index" },
+              link: {
+                type: "doc",
+                id: "getting-started/prerequisites/nodejs/index",
+              },
               items: [
                 "getting-started/prerequisites/nodejs/linux",
                 "getting-started/prerequisites/nodejs/windows",
@@ -44,7 +47,10 @@ const sidebars = {
             {
               type: "category",
               label: "React Native",
-              link: { type: "doc", id: "getting-started/prerequisites/react-native/index" },
+              link: {
+                type: "doc",
+                id: "getting-started/prerequisites/react-native/index",
+              },
               items: [
                 "getting-started/prerequisites/react-native/ios",
                 "getting-started/prerequisites/react-native/android",
@@ -59,21 +65,39 @@ const sidebars = {
       type: "category",
       label: "Concepts",
       link: { type: "doc", id: "concepts/index" },
-      items: ["concepts/agents", "concepts/did-and-didcomm", "concepts/platform-and-environment"],
+      items: [
+        "concepts/agents",
+        "concepts/did-and-didcomm",
+        "concepts/platform-and-environment",
+      ],
     },
     {
       type: "category",
       label: "Tutorials",
       link: { type: "doc", id: "tutorials/index" },
-      items: ["tutorials/agent-config", "tutorials/create-a-connection", "tutorials/issue-a-credential"],
+      items: [
+        "tutorials/agent-config",
+        "tutorials/create-a-connection",
+        "tutorials/issue-a-credential",
+      ],
+    },
+    {
+      type: "category",
+      label: "Updating",
+      link: { type: "doc", id: "updating/index" },
+      items: ["updating/update-assistant", "updating/versions/0.1-to-0.2"],
     },
     {
       type: "category",
       label: "Ecosystem",
       link: { type: "doc", id: "ecosystem/index" },
-      items: ["ecosystem/framework", "ecosystem/extensions", "ecosystem/bifold"],
+      items: [
+        "ecosystem/framework",
+        "ecosystem/extensions",
+        "ecosystem/bifold",
+      ],
     },
   ],
-}
+};
 
-module.exports = sidebars
+module.exports = sidebars;


### PR DESCRIPTION
Adds most of the documentation for migration to 0.2.0. Still need to do the credentials module.

Are there any other breaking changes you have noticed that we shoiuld mention here? We can also add them later as we discover them, but would be good to cover as much as possible.