### PR TITLE
ci: add aries.js.org CNAME

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
+          cname: aries.js.org
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
Adds the aries.js.org CNAME for deployments as described by https://js.org. 

Next step is to add the project to the js.org repo:

> To finish the procedure, make a pull request in our GitHub [repository](https://github.com/js-org/js.org/tree/master) that adds your subdomain to the list of existing JS.ORG domains. Your new URL should go live within 24 hours (keep an eye on your pull request in case of a naming conflict or a question from our side).

I think we should first move the repo to HL (but we can already merge this PR). Would like to have this al ready before the 0.2.0 release